### PR TITLE
Feature/data 321 add datastream resources to terraform

### DIFF
--- a/environments/dev/datastream.tf
+++ b/environments/dev/datastream.tf
@@ -4,8 +4,8 @@ data "google_secret_manager_secret_version" "bitrix_read_replica_password" {
 }
 
 resource "google_datastream_connection_profile" "bitrix_chat_mysql_connection" {
-  display_name              = "${var.env}-bitrix-chat-connection"
-  connection_profile_id     = "${var.env}-bitrix-chat-connection"
+  display_name              = "bitrix-chat"
+  connection_profile_id     = "bitrix-chat"
   location                  = var.region
   create_without_validation = false
 
@@ -13,25 +13,23 @@ resource "google_datastream_connection_profile" "bitrix_chat_mysql_connection" {
     hostname = "bitrix-read-replica.ctzlfpmjufbh.eu-west-2.rds.amazonaws.com"
     port     = 3306
     username = "admin"
-
     password = data.google_secret_manager_secret_version.bitrix_read_replica_password.secret_data
   }
 }
 
+# Imported from GCP sincere-hybrid-364510
 resource "google_datastream_connection_profile" "bigquery_sink_connection" {
-  display_name              = "${var.env}-bigquery-sink-connection"
-  connection_profile_id     = "${var.env}-bigquery-sink-connection"
+  display_name              = "bigquery-sink"
+  connection_profile_id     = "bigquery-sink"
   location                  = var.region
-  create_without_validation = false
 
   bigquery_profile {}
 }
 
-
 resource "google_datastream_stream" "bitrx_chat_mysql_to_bigquery" {
-    display_name = "${var.env}-eu-west-2-mysql-bitrix-read-replica-sitemanager-db-to-bq"
+    display_name = "eu-west-2-mysql-bitrix-read-replica-sitemanager-db-to-bq"
     location     = var.region
-    stream_id    = "${var.env}-eu-west-2-mysql-bitrix-read-replica-sitemanager-db-to-bq"
+    stream_id    = "eu-west-2-mysql-bitrix-read-replica-sitemanager-db-to-bq"
 
     source_config {
         source_connection_profile = google_datastream_connection_profile.bitrix_chat_mysql_connection.id
@@ -64,8 +62,71 @@ resource "google_datastream_stream" "bitrx_chat_mysql_to_bigquery" {
             source_hierarchy_datasets {
                 dataset_template {
                     location = var.region
-                    dataset_id_prefix = "${var.env}_bitrix_chat_"
+                    dataset_id_prefix = "bitrix_chat_"
                 }
+            }
+            merge {}
+        }
+    }
+
+    backfill_all {}
+    create_without_validation = false
+    desired_state = "RUNNING"
+}
+
+data "google_secret_manager_secret_version" "filament_read_replica_password" {
+  secret  = "filament-read-replica-password"
+  project = var.project
+}
+
+# Can't import existing Connection profile to Terraform config without triggering to recreate it
+# Just use this resource config when migrating to main projects
+resource "google_datastream_connection_profile" "filament_mysql_connection" {
+  display_name              = "${var.env}-filament-connection"
+  connection_profile_id     = "${var.env}-filament-connection"
+  location                  = var.region
+  create_without_validation = false
+
+  mysql_profile {
+    hostname = "filament-read-replica.ctzlfpmjufbh.eu-west-2.rds.amazonaws.com"
+    port     = 3306
+    username = "data_team"
+    password = data.google_secret_manager_secret_version.filament_read_replica_password.secret_data
+  }
+}
+
+resource "google_datastream_stream" "filament_mysql_to_bigquery" {
+    display_name = "${var.env}-eu-west2-mysql-filament-prod-db-to-bq"
+    location     = var.region
+    stream_id    = "${var.env}-eu-west2-mysql-filament-prod-db-to-bq"
+
+    source_config {
+        source_connection_profile = google_datastream_connection_profile.filament_mysql_connection.id
+        mysql_source_config {
+          include_objects {
+            mysql_databases  {
+              database = "filament_prod"
+            }
+            mysql_databases  {
+              database = "filament_staging"
+            }
+            mysql_databases  {
+              database = "filament_test"
+            }
+            mysql_databases  {
+              database = "vapor"
+            }
+          }
+          binary_log_position {}
+        }
+    }
+
+    destination_config {
+        destination_connection_profile = google_datastream_connection_profile.bigquery_sink_connection.id
+        bigquery_destination_config {
+            data_freshness = "900s"
+            single_target_dataset {
+              dataset_id = "${var.project}:filament"
             }
             merge {}
         }

--- a/environments/dev/datastream.tf
+++ b/environments/dev/datastream.tf
@@ -1,0 +1,77 @@
+data "google_secret_manager_secret_version" "bitrix_read_replica_password" {
+  secret  = "bitrix-read-replica-password"
+  project = var.project
+}
+
+resource "google_datastream_connection_profile" "bitrix_chat_mysql_connection" {
+  display_name              = "${var.env}-bitrix-chat-connection"
+  connection_profile_id     = "${var.env}-bitrix-chat-connection"
+  location                  = var.region
+  create_without_validation = false
+
+  mysql_profile {
+    hostname = "bitrix-read-replica.ctzlfpmjufbh.eu-west-2.rds.amazonaws.com"
+    port     = 3306
+    username = "admin"
+
+    password = data.google_secret_manager_secret_version.bitrix_read_replica_password.secret_data
+  }
+}
+
+resource "google_datastream_connection_profile" "bigquery_sink_connection" {
+  display_name              = "${var.env}-bigquery-sink-connection"
+  connection_profile_id     = "${var.env}-bigquery-sink-connection"
+  location                  = var.region
+  create_without_validation = false
+
+  bigquery_profile {}
+}
+
+
+resource "google_datastream_stream" "bitrx_chat_mysql_to_bigquery" {
+    display_name = "${var.env}-eu-west-2-mysql-bitrix-read-replica-sitemanager-db-to-bq"
+    location     = var.region
+    stream_id    = "${var.env}-eu-west-2-mysql-bitrix-read-replica-sitemanager-db-to-bq"
+
+    source_config {
+        source_connection_profile = google_datastream_connection_profile.bitrix_chat_mysql_connection.id
+        mysql_source_config {
+          include_objects {
+            mysql_databases  {
+              database = "sitemanager"
+              mysql_tables {
+                  table = "b_im_message"
+              }
+              mysql_tables {
+                  table = "b_user"
+              }
+              mysql_tables {
+                  table = "b_im_chat"
+              }
+                mysql_tables {
+                  table = "b_imopenlines_session"
+              }
+            }
+          }
+          binary_log_position {}
+        }
+    }
+
+    destination_config {
+        destination_connection_profile = google_datastream_connection_profile.bigquery_sink_connection.id
+        bigquery_destination_config {
+            data_freshness = "900s"
+            source_hierarchy_datasets {
+                dataset_template {
+                    location = var.region
+                    dataset_id_prefix = "${var.env}_bitrix_chat_"
+                }
+            }
+            merge {}
+        }
+    }
+
+    backfill_all {}
+    create_without_validation = false
+    desired_state = "NOT_STARTED"
+}

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -17,6 +17,15 @@ locals {
   env = "dev"
 }
 
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.16.0"
+    }
+  }
+}
+
 provider "google" {
   impersonate_service_account = "terraform-user@${var.project}.iam.gserviceaccount.com"
   project                     = var.project

--- a/environments/dev/sql.tf
+++ b/environments/dev/sql.tf
@@ -8,7 +8,7 @@ resource "google_sql_database_instance" "bitrix_get_data_mysql_instance" {
   master_instance_name = null
   name                 = "bitrix-get-data"
   project              = "sincere-hybrid-364510"
-  region               = "europe-west1"
+  region               = "europe-west1" # TODO: Update to europe-west2 when migrating to UAT and PROD
   replica_names        = []
   lifecycle {
     # [GAB] Currently these values are set to 0 and 0 respectively

--- a/environments/dev/sql.tf
+++ b/environments/dev/sql.tf
@@ -1,0 +1,152 @@
+# Imported from GCP sincere-hybrid-364510
+resource "google_sql_database_instance" "bitrix_get_data_mysql_instance" {
+  database_version     = "MYSQL_8_0_31"
+  deletion_protection  = true
+  encryption_key_name  = null
+  instance_type        = "CLOUD_SQL_INSTANCE"
+  maintenance_version  = "MYSQL_8_0_31.R20241208.01_00"
+  master_instance_name = null
+  name                 = "bitrix-get-data"
+  project              = "sincere-hybrid-364510"
+  region               = "europe-west1"
+  replica_names        = []
+  lifecycle {
+    # [GAB] Currently these values are set to 0 and 0 respectively
+    # however, Terraform does not allow these 0 values in the config
+    # and will force maintainers to update the values to appropriate ones
+    # (e.g. 7, and 1024 respectively) which will cause to update the 
+    # SQL instance
+    ignore_changes = [
+      settings[0].maintenance_window[0].day,
+      settings[0].insights_config[0].query_string_length,
+    ]
+  }
+  
+  settings {
+    activation_policy            = "ALWAYS"
+    availability_type            = "ZONAL"
+    collation                    = null
+    connector_enforcement        = "NOT_REQUIRED"
+    deletion_protection_enabled  = true
+    disk_autoresize              = true
+    disk_autoresize_limit        = 0
+    disk_size                    = 100
+    disk_type                    = "PD_SSD"
+    edition                      = "ENTERPRISE"
+    enable_dataplex_integration  = false
+    enable_google_ml_integration = false
+    pricing_plan                 = "PER_USE"
+    tier                         = "db-custom-1-3840"
+    time_zone                    = null
+    user_labels                  = {}
+    backup_configuration {
+      binary_log_enabled             = true
+      enabled                        = true
+      location                       = "eu"
+      point_in_time_recovery_enabled = false
+      start_time                     = "03:00"
+      transaction_log_retention_days = 7
+      backup_retention_settings {
+        retained_backups = 7
+        retention_unit   = "COUNT"
+      }
+    }
+    data_cache_config {
+      data_cache_enabled = false
+    }
+    insights_config {
+      query_insights_enabled  = false
+      query_plans_per_minute  = 0
+      query_string_length     = 1024
+      record_application_tags = false
+      record_client_address   = false
+    }
+    ip_configuration {
+      allocated_ip_range                            = null
+      enable_private_path_for_google_cloud_services = false
+      ipv4_enabled                                  = true
+      private_network                               = null
+      server_ca_mode                                = "GOOGLE_MANAGED_INTERNAL_CA"
+      server_ca_pool                                = null
+      ssl_mode                                      = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+
+      # Might have to update this when we migrate projects
+      authorized_networks {
+        expiration_time = null
+        name            = "bitrix-ip"
+        value           = "78.40.216.83"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream-eu-1"
+        value           = "35.189.120.213"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream-eu-2"
+        value           = "34.89.121.226"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream-eu-3"
+        value           = "34.105.244.177"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream-eu-4"
+        value           = "35.197.249.117"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream-eu-5"
+        value           = "35.242.151.51"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream1"
+        value           = "35.187.27.174"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream2"
+        value           = "104.199.6.64"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream3"
+        value           = "35.205.33.30"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastream4"
+        value           = "34.78.213.130"
+      }
+      authorized_networks {
+        expiration_time = null
+        name            = "datastrean5"
+        value           = "35.205.125.111"
+      }
+    }
+    location_preference {
+      follow_gae_application = null
+      secondary_zone         = null
+      zone                   = "europe-west1-d"
+    }
+    maintenance_window {
+      day          = 7
+      hour         = 0
+      update_track = "canary"
+    }
+  }
+}
+
+# Imported from GCP sincere-hybrid-364510
+# TODO: Figure out password or just create a new one and store to Secret Manager
+resource "google_sql_user" "bitrix_read_user" {
+  deletion_policy = null
+  host            = "%"
+  instance        = "bitrix-get-data"
+  name            = "bitrix-read-user"
+  project         = var.project
+  type            = null
+}


### PR DESCRIPTION
1. Added Datastream connection profile bitrix-chat to Terraform
- Recreated via Terraform

2. Added Datastream connection profile bigquery-sink to Terraform
- Imported existing resource in sincere-hybrid-364510 to current Terraform state

3. Added Datastream eu-west-2-mysql-bitrix-read-replica-sitemanager-db-to-bq to Terraform
- Recreated resource via Terraform

4. Added Datastream connection profile dev-filament-connection to Terraform
- Could not import existing filament-connection connection profile to Terraform state without recreating so we will just recreate the resource when migrating to the new GCP project

5. Added Datastream dev-eu-west2-mysql-filament-prod-db-to-bq to Terraform
- Could not import existing eu-west2-mysql-filament-prod-db-to-bq  Datastream stream to Terraform state without recreating so we will just recreate the resource when migrating to the new GCP project

6. Added SQL Instance bitrix-read-data to Terraform
- Imported existing resource in sincere-hybrid-364510 to current Terraform state

7. Added SQL user bitrx-read-user to Terraform 
- Imported existing resource in sincere-hybrid-364510 to current Terraform state
