### PR TITLE
Feature/data 484 set up resources for hightouch reverse etl

### DIFF
--- a/environments/dev/cloud_build.tf
+++ b/environments/dev/cloud_build.tf
@@ -57,7 +57,8 @@ resource "google_service_account" "dev_cloud_composer_cloud_build_service_accoun
 resource "google_project_iam_member" "dev_cloud_composer_cloud_build_service_account" {
   for_each = toset([
     "roles/storage.objectAdmin",
-    "roles/logging.logWriter"
+    "roles/logging.logWriter",
+    "roles/artifactregistry.writer"
   ])
 
   project = "sincere-hybrid-364510"

--- a/environments/dev/compute_engine.tf
+++ b/environments/dev/compute_engine.tf
@@ -20,7 +20,7 @@ resource "google_compute_instance" "airbyte-dbt-sandbox" {
     goog-ec-src = "vm_add-tf"
   }
 
-  machine_type = "n2-highcpu-64"
+  machine_type = "e2-standard-32"
   name         = "airbyte-dbt-sandbox"
 
   network_interface {

--- a/environments/dev/hightouch.tf
+++ b/environments/dev/hightouch.tf
@@ -1,0 +1,64 @@
+locals {
+  hightouch_reverse_etl_required_roles = [
+    "roles/bigquery.user",
+    "roles/bigquery.dataViewer",
+  ]
+}
+
+resource "google_service_account" "hightouch_reverse_etl_service_account" {
+  account_id   = "${var.env}-hightouch-reverse-etl-sa"
+  display_name = "Service account for ${var.env} Hightouch Reverse ETL"
+}
+
+resource "google_project_iam_member" "hightouch_reverse_etl_service_account" {
+  for_each = toset(local.hightouch_reverse_etl_required_roles)
+  project  = var.project
+  member   = "serviceAccount:${google_service_account.hightouch_reverse_etl_service_account.email}"
+  role     = each.key
+}
+
+module "hightouch_audit_dataset" {
+  source         = "../../modules/dataset"
+  project        = var.project
+  dataset_name   = "hightouch_audit"
+  default_region = var.region
+}
+
+module "hightouch_planner_dataset" {
+  source         = "../../modules/dataset"
+  project        = var.project
+  dataset_name   = "hightouch_planner"
+  default_region = var.region
+}
+
+resource "google_bigquery_dataset_access" "hightouch_audit_data_editor" {
+  dataset_id = module.hightouch_audit_dataset.dataset_id
+  project    = var.project
+
+  role          = "roles/bigquery.dataEditor"
+  user_by_email = google_service_account.hightouch_reverse_etl_service_account.email
+}
+
+resource "google_bigquery_dataset_access" "hightouch_audit_data_viewer" {
+  dataset_id = module.hightouch_audit_dataset.dataset_id
+  project    = var.project
+
+  role          = "roles/bigquery.dataViewer"
+  user_by_email = google_service_account.hightouch_reverse_etl_service_account.email
+}
+
+resource "google_bigquery_dataset_access" "hightouch_planner_data_editor" {
+  dataset_id = module.hightouch_planner_dataset.dataset_id
+  project    = var.project
+
+  role          = "roles/bigquery.dataEditor"
+  user_by_email = google_service_account.hightouch_reverse_etl_service_account.email
+}
+
+resource "google_bigquery_dataset_access" "hightouch_planner_data_viewer" {
+  dataset_id = module.hightouch_planner_dataset.dataset_id
+  project    = var.project
+
+  role          = "roles/bigquery.dataViewer"
+  user_by_email = google_service_account.hightouch_reverse_etl_service_account.email
+}


### PR DESCRIPTION
Via Terraform set up the following resources:

Service account with the ff. roles:
1. roles/bigquery.user
2. roles/bigquery.dataViewer

BigQuery datasets
1. hightouch_audit
2. hightouch_planner

Grant IAM roles to service account created above on the created BigQuery datasets

1. roles/bigquery.dataViewer(redundant? Just followed the steps from Hightouch docs)
2. roles/bigquery.dataEditor